### PR TITLE
[FLINK-8375][network] Remove unnecessary synchronization

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -192,8 +192,6 @@ public class ResultPartitionTest {
 
 		partition.writeBufferToAllSubpartitions(buffer);
 
-		// Verify added to all queues, i.e. two buffers in total
-		assertEquals(2, partition.getTotalNumberOfBuffers());
 		// release the buffers in the partition
 		partition.release();
 


### PR DESCRIPTION
Synchronized blocks in ResultPartition could affect only:
1. totalNumberOfBuffers and totalNumberOfBytes counters
2. subpartition add(), finish() and release() calls.

However:
1. accessors to the counters where not synchronized.
2a. add(), finish() and release() methods for PipelinedSubpartition were already threads safe
2b. add(), finish() and release() methods for SpillableSubpartition were made thread safe in
this commit, by basically pushing synchronized section down one level.