### PR TITLE
[FLINK-8371][network] always recycle Buffers when releasing SpillableSubpartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -136,7 +136,6 @@ class PipelinedSubpartition extends ResultSubpartition {
 				buffer.recycle();
 			}
 
-			// Get the view...
 			view = readView;
 			readView = null;
 
@@ -146,7 +145,6 @@ class PipelinedSubpartition extends ResultSubpartition {
 
 		LOG.debug("Released {}.", this);
 
-		// Release all resources of the view
 		if (view != null) {
 			view.releaseAllResources();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
@@ -169,6 +169,13 @@ class SpillableSubpartitionView implements ResultSubpartitionView {
 			if (spilled != null) {
 				spilled.releaseAllResources();
 			}
+			// we are never giving this buffer out in getNextBuffer(), so we need to clean it up
+			synchronized (buffers) {
+				if (nextBuffer != null) {
+					nextBuffer.recycle();
+					nextBuffer = null;
+				}
+			}
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -19,9 +19,11 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.util.TestConsumerCallback;
@@ -29,7 +31,9 @@ import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
 import org.apache.flink.runtime.io.network.util.TestProducerSource;
 import org.apache.flink.runtime.io.network.util.TestSubpartitionConsumer;
 import org.apache.flink.runtime.io.network.util.TestSubpartitionProducer;
+
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
@@ -258,5 +262,73 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 		// Wait for producer and consumer to finish
 		producerResult.get();
 		consumerResult.get();
+	}
+
+
+	/**
+	 * Tests cleanup of {@link PipelinedSubpartition#release()} with no read view attached.
+	 */
+	@Test
+	public void testCleanupReleasedPartitionNoView() throws Exception {
+		testCleanupReleasedPartition(false);
+	}
+
+	/**
+	 * Tests cleanup of {@link PipelinedSubpartition#release()} with a read view attached.
+	 */
+	@Test
+	public void testCleanupReleasedPartitionWithView() throws Exception {
+		testCleanupReleasedPartition(true);
+	}
+
+	/**
+	 * Tests cleanup of {@link PipelinedSubpartition#release()}.
+	 *
+	 * @param createView
+	 * 		whether the partition should have a view attached to it (<tt>true</tt>) or not (<tt>false</tt>)
+	 */
+	private void testCleanupReleasedPartition(boolean createView) throws Exception {
+		PipelinedSubpartition partition = createSubpartition();
+
+		Buffer buffer1 = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
+			FreeingBufferRecycler.INSTANCE);
+		Buffer buffer2 = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
+			FreeingBufferRecycler.INSTANCE);
+		boolean buffer1Recycled;
+		boolean buffer2Recycled;
+		try {
+			partition.add(buffer1);
+			partition.add(buffer2);
+			// create the read view first
+			ResultSubpartitionView view = null;
+			if (createView) {
+				view = partition.createReadView(numBuffers -> {});
+			}
+
+			partition.release();
+
+			assertTrue(partition.isReleased());
+			if (createView) {
+				assertTrue(view.isReleased());
+			}
+			assertTrue(buffer1.isRecycled());
+		} finally {
+			buffer1Recycled = buffer1.isRecycled();
+			if (!buffer1Recycled) {
+				buffer1.recycle();
+			}
+			buffer2Recycled = buffer2.isRecycled();
+			if (!buffer2Recycled) {
+				buffer2.recycle();
+			}
+		}
+		if (!buffer1Recycled) {
+			Assert.fail("buffer 1 not recycled");
+		}
+		if (!buffer2Recycled) {
+			Assert.fail("buffer 2 not recycled");
+		}
+		assertEquals(2, partition.getTotalNumberOfBuffers());
+		assertEquals(2 * 4096, partition.getTotalNumberOfBytes());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
@@ -413,10 +413,10 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 				buffer.recycle();
 				Assert.fail("buffer not recycled");
 			}
-			// still same statistics
-			assertEquals(1, partition.getTotalNumberOfBuffers());
-			assertEquals(4, partition.getTotalNumberOfBytes());
 		}
+		// still same statistics
+		assertEquals(1, partition.getTotalNumberOfBuffers());
+		assertEquals(4, partition.getTotalNumberOfBytes());
 	}
 
 	/**
@@ -451,16 +451,20 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 
 		Buffer buffer = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
 			FreeingBufferRecycler.INSTANCE);
+		boolean bufferRecycled;
 		try {
 			partition.add(buffer);
 		} finally {
-			if (!buffer.isRecycled()) {
+			bufferRecycled = buffer.isRecycled();
+			if (!bufferRecycled) {
 				buffer.recycle();
-				Assert.fail("buffer not recycled");
 			}
-			assertEquals(0, partition.getTotalNumberOfBuffers());
-			assertEquals(0, partition.getTotalNumberOfBytes());
 		}
+		if (!bufferRecycled) {
+			Assert.fail("buffer not recycled");
+		}
+		assertEquals(0, partition.getTotalNumberOfBuffers());
+		assertEquals(0, partition.getTotalNumberOfBytes());
 	}
 
 	/**
@@ -476,17 +480,21 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 
 		Buffer buffer = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
 			FreeingBufferRecycler.INSTANCE);
+		boolean bufferRecycled;
 		try {
 			partition.add(buffer);
 		} finally {
 			ioManager.shutdown();
-			if (buffer.isRecycled()) {
-				Assert.fail("buffer recycled before the write operation completed");
+			bufferRecycled = buffer.isRecycled();
+			if (!bufferRecycled) {
+				buffer.recycle();
 			}
-			buffer.recycle();
-			assertEquals(1, partition.getTotalNumberOfBuffers());
-			assertEquals(4096, partition.getTotalNumberOfBytes());
 		}
+		if (bufferRecycled) {
+			Assert.fail("buffer recycled before the write operation completed");
+		}
+		assertEquals(1, partition.getTotalNumberOfBuffers());
+		assertEquals(4096, partition.getTotalNumberOfBytes());
 	}
 
 	/**
@@ -549,10 +557,10 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 			if (!buffer2.isRecycled()) {
 				buffer2.recycle();
 			}
-			// note: a view requires a finished partition which has an additional EndOfPartitionEvent
-			assertEquals(2 + (createView ? 1 : 0), partition.getTotalNumberOfBuffers());
-			assertEquals(4096 * 2 + (createView ? 4 : 0), partition.getTotalNumberOfBytes());
 		}
+		// note: a view requires a finished partition which has an additional EndOfPartitionEvent
+		assertEquals(2 + (createView ? 1 : 0), partition.getTotalNumberOfBuffers());
+		assertEquals(4096 * 2 + (createView ? 4 : 0), partition.getTotalNumberOfBytes());
 	}
 
 	/**
@@ -569,18 +577,21 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 
 		Buffer buffer = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
 			FreeingBufferRecycler.INSTANCE);
+		boolean bufferRecycled;
 		try {
 			partition.add(buffer);
 		} finally {
 			ioManager.shutdown();
-
-			if (!buffer.isRecycled()) {
+			bufferRecycled = buffer.isRecycled();
+			if (!bufferRecycled) {
 				buffer.recycle();
-				Assert.fail("buffer not recycled");
 			}
-			assertEquals(0, partition.getTotalNumberOfBuffers());
-			assertEquals(0, partition.getTotalNumberOfBytes());
 		}
+		if (!bufferRecycled) {
+			Assert.fail("buffer not recycled");
+		}
+		assertEquals(0, partition.getTotalNumberOfBuffers());
+		assertEquals(0, partition.getTotalNumberOfBytes());
 	}
 
 	private static class AwaitableBufferAvailablityListener implements BufferAvailabilityListener {


### PR DESCRIPTION
## What is the purpose of the change

There were places where `Buffer` instances were not released upon `SpillableSubpartition#release()` with a view attached to a non-spilled subpartition:

1) `SpillableSubpartition#buffer`: `SpillableSubpartition#release()` delegates the recycling to the view, but `SpillableSubpartitionView` does not clean up the `buffers` queue (the recycling was only done by the subpartition if there was no view).
2) `SpillableSubpartitionView#nextBuffer`: If this field is populated when the subpartition is released, it will neither be given out in subsequent `SpillableSubpartitionView#getNextBuffer()` calls (there was a short path returning `null` here), nor was it recycled

## Brief change log

- similarly to the `PipelinesSubpartition` implementation, make `SpillableSubpartition#release()` always clean up and recycle the buffers
- recycle `SpillableSubpartitionView#nextBuffer` in `SpillableSubpartitionView#releaseAllResources()`

## Verifying this change

This change added tests and can be verified as follows:

- added tests for various scenarios releasing a spillable/spilled or pipelined subpartition

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dataartisans/flink/3)
<!-- Reviewable:end -->

  