### PR TITLE
[FLINK-7518][network] pass our own NetworkBuffer to Netty

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -155,8 +155,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 					}
 
 					// retain the buffer so that it can be recycled by each channel of targetPartition
-					eventBuffer.retainBuffer();
-					targetPartition.writeBuffer(eventBuffer, targetChannel);
+					targetPartition.writeBuffer(eventBuffer.readOnlySlice().retainBuffer(), targetChannel);
 				}
 			}
 		} finally {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -21,16 +21,18 @@ package org.apache.flink.runtime.io.network.netty;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufInputStream;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufOutputStream;
+import org.apache.flink.shaded.netty4.io.netty.buffer.CompositeByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -63,7 +65,7 @@ public abstract class NettyMessage {
 	// constructor in order to work with the generic deserializer.
 	// ------------------------------------------------------------------------
 
-	static final int HEADER_LENGTH = 4 + 4 + 1; // frame length (4), magic number (4), msg ID (1)
+	static final int FRAME_HEADER_LENGTH = 4 + 4 + 1; // frame length (4), magic number (4), msg ID (1)
 
 	static final int MAGIC_NUMBER = 0xBADC0FFE;
 
@@ -94,31 +96,63 @@ public abstract class NettyMessage {
 	 * Allocates a new (header and contents) buffer and adds some header information for the frame
 	 * decoder.
 	 *
-	 * <p>If the <tt>length</tt> is unknown, you must write the actual length after adding the
-	 * contents as an integer to position <tt>0</tt>!
+	 * <p>If the <tt>contentLength</tt> is unknown, you must write the actual length after adding
+	 * the contents as an integer to position <tt>0</tt>!
 	 *
 	 * @param allocator
 	 * 		byte buffer allocator to use
 	 * @param id
 	 * 		{@link NettyMessage} subclass ID
-	 * @param length
+	 * @param contentLength
 	 * 		content length (or <tt>-1</tt> if unknown)
 	 *
 	 * @return a newly allocated direct buffer with header data written for {@link
 	 * NettyMessageDecoder}
 	 */
-	private static ByteBuf allocateBuffer(ByteBufAllocator allocator, byte id, int length) {
-		checkArgument(length <= Integer.MAX_VALUE - HEADER_LENGTH);
+	private static ByteBuf allocateBuffer(ByteBufAllocator allocator, byte id, int contentLength) {
+		return allocateBuffer(allocator, id, 0, contentLength, true);
+	}
+
+	/**
+	 * Allocates a new buffer and adds some header information for the frame decoder.
+	 *
+	 * <p>If the <tt>contentLength</tt> is unknown, you must write the actual length after adding
+	 * the contents as an integer to position <tt>0</tt>!
+	 *
+	 * @param allocator
+	 * 		byte buffer allocator to use
+	 * @param id
+	 * 		{@link NettyMessage} subclass ID
+	 * @param messageHeaderLength
+	 * 		additional header length that should be part of the allocated buffer and is written
+	 * 		outside of this method
+	 * @param contentLength
+	 * 		content length (or <tt>-1</tt> if unknown)
+	 * @param allocateForContent
+	 * 		whether to make room for the actual content in the buffer (<tt>true</tt>) or whether to
+	 * 		only return a buffer with the header information (<tt>false</tt>)
+	 *
+	 * @return a newly allocated direct buffer with header data written for {@link
+	 * NettyMessageDecoder}
+	 */
+	private static ByteBuf allocateBuffer(
+			ByteBufAllocator allocator,
+			byte id,
+			int messageHeaderLength,
+			int contentLength,
+			boolean allocateForContent) {
+		checkArgument(contentLength <= Integer.MAX_VALUE - FRAME_HEADER_LENGTH);
 
 		final ByteBuf buffer;
-		if (length != -1) {
-			buffer = allocator.directBuffer(HEADER_LENGTH + length);
+		if (!allocateForContent) {
+			buffer = allocator.directBuffer(FRAME_HEADER_LENGTH + messageHeaderLength);
+		} else if (contentLength != -1) {
+			buffer = allocator.directBuffer(FRAME_HEADER_LENGTH + messageHeaderLength + contentLength);
 		} else {
-			// content length unknown -> start with the default initial size (rather than HEADER_LENGTH only):
+			// content length unknown -> start with the default initial size (rather than FRAME_HEADER_LENGTH only):
 			buffer = allocator.directBuffer();
 		}
-
-		buffer.writeInt(HEADER_LENGTH + length);
+		buffer.writeInt(FRAME_HEADER_LENGTH + messageHeaderLength + contentLength); // may be updated later, e.g. if contentLength == -1
 		buffer.writeInt(MAGIC_NUMBER);
 		buffer.writeByte(id);
 
@@ -218,7 +252,7 @@ public abstract class NettyMessage {
 		private static final byte ID = 0;
 
 		@Nullable
-		final Buffer buffer;
+		final NetworkBuffer buffer;
 
 		final InputChannelID receiverId;
 
@@ -248,7 +282,7 @@ public abstract class NettyMessage {
 			this.backlog = backlog;
 		}
 
-		BufferResponse(Buffer buffer, int sequenceNumber, InputChannelID receiverId, int backlog) {
+		BufferResponse(NetworkBuffer buffer, int sequenceNumber, InputChannelID receiverId, int backlog) {
 			this.buffer = checkNotNull(buffer);
 			this.retainedSlice = null;
 			this.isBuffer = buffer.isBuffer();
@@ -279,33 +313,38 @@ public abstract class NettyMessage {
 		@Override
 		ByteBuf write(ByteBufAllocator allocator) throws IOException {
 			checkNotNull(buffer, "No buffer instance to serialize.");
+			// receiver ID (16), sequence number (4), backlog (4), isBuffer (1), buffer size (4)
+			final int messageHeaderLength = 16 + 4 + 4 + 1 + 4;
 
-
-			ByteBuf result = null;
+			ByteBuf headerBuf = null;
 			try {
-				ByteBuffer nioBufferReadable = buffer.getNioBufferReadable();
-				int length = 16 + 4 + 4 + 1 + 4 + nioBufferReadable.remaining();
+				// in order to forward the buffer to netty, it needs an allocator set
+				buffer.setAllocator(allocator);
 
-				result = allocateBuffer(allocator, ID, length);
+				// only allocate header buffer - we will combine it with the data buffer below
+				headerBuf = allocateBuffer(allocator, ID, messageHeaderLength, buffer.readableBytes(), false);
 
-				receiverId.writeTo(result);
-				result.writeInt(sequenceNumber);
-				result.writeInt(backlog);
-				result.writeBoolean(buffer.isBuffer());
-				result.writeInt(nioBufferReadable.remaining());
-				result.writeBytes(nioBufferReadable);
+				receiverId.writeTo(headerBuf);
+				headerBuf.writeInt(sequenceNumber);
+				headerBuf.writeInt(backlog);
+				headerBuf.writeBoolean(buffer.isBuffer());
+				headerBuf.writeInt(buffer.readableBytes());
 
-				return result;
+				CompositeByteBuf composityBuf = allocator.compositeDirectBuffer();
+				composityBuf.addComponent(headerBuf);
+				composityBuf.addComponent(buffer);
+				// update writer index since we have data written to the components:
+				composityBuf.writerIndex(headerBuf.writerIndex() + buffer.writerIndex());
+				return composityBuf;
 			}
 			catch (Throwable t) {
-				if (result != null) {
-					result.release();
+				if (headerBuf != null) {
+					headerBuf.release();
 				}
-
-				throw new IOException(t);
-			}
-			finally {
 				buffer.recycleBuffer();
+
+				ExceptionUtils.rethrowIOException(t);
+				return null; // silence the compiler
 			}
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.netty;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.ErrorResponse;
 import org.apache.flink.runtime.io.network.partition.ProducerFailedException;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel.BufferAndAvailability;
@@ -191,7 +192,7 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
 						}
 
 						BufferResponse msg = new BufferResponse(
-							next.buffer(),
+							(NetworkBuffer) next.buffer(),
 							reader.getSequenceNumber(),
 							reader.getReceiverId(),
 							0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
 import org.apache.flink.runtime.io.network.util.TestTaskEvent;
@@ -74,6 +75,7 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -126,7 +128,7 @@ public class RecordWriterTest {
 			BufferProvider bufferProvider = mock(BufferProvider.class);
 			when(bufferProvider.requestBufferBuilderBlocking()).thenAnswer(request);
 
-			ResultPartitionWriter partitionWriter = createResultPartitionWriter(bufferProvider);
+			ResultPartitionWriter partitionWriter = spy(new RecyclingPartitionWriter(bufferProvider));
 
 			final RecordWriter<IntValue> recordWriter = new RecordWriter<IntValue>(partitionWriter);
 
@@ -306,8 +308,8 @@ public class RecordWriterTest {
 
 	@Test
 	public void testSerializerClearedAfterClearBuffers() throws Exception {
-		ResultPartitionWriter partitionWriter = createResultPartitionWriter(
-			new TestPooledBufferProvider(1, 16));
+		ResultPartitionWriter partitionWriter =
+			spy(new RecyclingPartitionWriter(new TestPooledBufferProvider(1, 16)));
 
 		RecordWriter<IntValue> recordWriter = new RecordWriter<IntValue>(partitionWriter);
 
@@ -332,14 +334,14 @@ public class RecordWriterTest {
 		int bufferSize = 32;
 
 		@SuppressWarnings("unchecked")
-		Queue<BufferOrEvent>[] queues = new Queue[numChannels];
+		Queue<Buffer>[] queues = new Queue[numChannels];
 		for (int i = 0; i < numChannels; i++) {
 			queues[i] = new ArrayDeque<>();
 		}
 
 		TestPooledBufferProvider bufferProvider = new TestPooledBufferProvider(Integer.MAX_VALUE, bufferSize);
 
-		ResultPartitionWriter partitionWriter = createCollectingPartitionWriter(queues, bufferProvider);
+		ResultPartitionWriter partitionWriter = new CollectingPartitionWriter(queues, bufferProvider);
 		RecordWriter<ByteArrayIO> writer = new RecordWriter<>(partitionWriter, new RoundRobin<ByteArrayIO>());
 		CheckpointBarrier barrier = new CheckpointBarrier(Integer.MAX_VALUE + 919192L, Integer.MAX_VALUE + 18828228L, CheckpointOptions.forCheckpoint());
 
@@ -348,11 +350,12 @@ public class RecordWriterTest {
 
 		assertEquals(0, bufferProvider.getNumberOfCreatedBuffers());
 
-		for (Queue<BufferOrEvent> queue : queues) {
-			assertEquals(1, queue.size());
-			BufferOrEvent boe = queue.remove();
+		for (int i = 0; i < numChannels; i++) {
+			assertEquals(1, queues[i].size());
+			BufferOrEvent boe = parseBuffer(queues[i].remove(), i);
 			assertTrue(boe.isEvent());
 			assertEquals(barrier, boe.getEvent());
+			assertEquals(0, queues[i].size());
 		}
 	}
 
@@ -368,14 +371,14 @@ public class RecordWriterTest {
 		int lenBytes = 4; // serialized length
 
 		@SuppressWarnings("unchecked")
-		Queue<BufferOrEvent>[] queues = new Queue[numChannels];
+		Queue<Buffer>[] queues = new Queue[numChannels];
 		for (int i = 0; i < numChannels; i++) {
 			queues[i] = new ArrayDeque<>();
 		}
 
 		TestPooledBufferProvider bufferProvider = new TestPooledBufferProvider(Integer.MAX_VALUE, bufferSize);
 
-		ResultPartitionWriter partitionWriter = createCollectingPartitionWriter(queues, bufferProvider);
+		ResultPartitionWriter partitionWriter = new CollectingPartitionWriter(queues, bufferProvider);
 		RecordWriter<ByteArrayIO> writer = new RecordWriter<>(partitionWriter, new RoundRobin<ByteArrayIO>());
 		CheckpointBarrier barrier = new CheckpointBarrier(Integer.MAX_VALUE + 1292L, Integer.MAX_VALUE + 199L, CheckpointOptions.forCheckpoint());
 
@@ -408,10 +411,22 @@ public class RecordWriterTest {
 
 		assertEquals(4, bufferProvider.getNumberOfCreatedBuffers());
 
+		BufferOrEvent boe;
 		assertEquals(2, queues[0].size()); // 1 buffer + 1 event
+		assertTrue(parseBuffer(queues[0].remove(), 0).isBuffer());
 		assertEquals(3, queues[1].size()); // 2 buffers + 1 event
+		assertTrue(parseBuffer(queues[1].remove(), 1).isBuffer());
+		assertTrue(parseBuffer(queues[1].remove(), 1).isBuffer());
 		assertEquals(2, queues[2].size()); // 1 buffer + 1 event
+		assertTrue(parseBuffer(queues[2].remove(), 2).isBuffer());
 		assertEquals(1, queues[3].size()); // 0 buffers + 1 event
+
+		// every queue's last element should be the event
+		for (int i = 0; i < numChannels; i++) {
+			boe = parseBuffer(queues[i].remove(), i);
+			assertTrue(boe.isEvent());
+			assertEquals(barrier, boe.getEvent());
+		}
 	}
 
 	/**
@@ -430,11 +445,10 @@ public class RecordWriterTest {
 			.toReturn(buffer);
 
 		@SuppressWarnings("unchecked")
-		ArrayDeque<BufferOrEvent>[] queues =
-			new ArrayDeque[]{new ArrayDeque(), new ArrayDeque()};
+		ArrayDeque<Buffer>[] queues = new ArrayDeque[] { new ArrayDeque(), new ArrayDeque() };
 
 		ResultPartitionWriter partition =
-			createCollectingPartitionWriter(queues, new TestPooledBufferProvider(Integer.MAX_VALUE));
+			new CollectingPartitionWriter(queues, new TestPooledBufferProvider(Integer.MAX_VALUE));
 		RecordWriter<?> writer = new RecordWriter<>(partition);
 
 		writer.broadcastEvent(EndOfPartitionEvent.INSTANCE);
@@ -443,51 +457,17 @@ public class RecordWriterTest {
 		assertEquals(1, queues[0].size());
 		assertEquals(1, queues[1].size());
 
+		// process all collected events (recycles the buffer)
+		for (int i = 0; i < queues.length; i++) {
+			assertTrue(parseBuffer(queues[i].remove(), i).isEvent());
+		}
+
 		assertTrue(buffer.isRecycled());
 	}
 
 	// ---------------------------------------------------------------------------------------------
 	// Helpers
 	// ---------------------------------------------------------------------------------------------
-
-	/**
-	 * Creates a mock partition writer that collects the added buffers/events.
-	 *
-	 * <p>This much mocking should not be necessary with better designed
-	 * interfaces. Refactoring this will take too much time now though, hence
-	 * the mocking. Ideally, we will refactor all of this mess in order to make
-	 * our lives easier and test it better.
-	 */
-	private ResultPartitionWriter createCollectingPartitionWriter(
-			final Queue<BufferOrEvent>[] queues,
-			BufferProvider bufferProvider) throws IOException {
-
-		int numChannels = queues.length;
-
-		ResultPartitionWriter partitionWriter = mock(ResultPartitionWriter.class);
-		when(partitionWriter.getBufferProvider()).thenReturn(checkNotNull(bufferProvider));
-		when(partitionWriter.getNumberOfSubpartitions()).thenReturn(numChannels);
-
-		doAnswer(new Answer<Void>() {
-			@Override
-			public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
-				Buffer buffer = (Buffer) invocationOnMock.getArguments()[0];
-				if (buffer.isBuffer()) {
-					Integer targetChannel = (Integer) invocationOnMock.getArguments()[1];
-					queues[targetChannel].add(new BufferOrEvent(buffer, targetChannel));
-				} else {
-					// is event:
-					AbstractEvent event = EventSerializer.fromBuffer(buffer, getClass().getClassLoader());
-					buffer.recycleBuffer(); // the buffer is not needed anymore
-					Integer targetChannel = (Integer) invocationOnMock.getArguments()[1];
-					queues[targetChannel].add(new BufferOrEvent(event, targetChannel));
-				}
-				return null;
-			}
-		}).when(partitionWriter).writeBuffer(any(Buffer.class), anyInt());
-
-		return partitionWriter;
-	}
 
 	private BufferProvider createBufferProvider(final int bufferSize)
 			throws IOException, InterruptedException {
@@ -519,24 +499,97 @@ public class RecordWriterTest {
 		return bufferProvider;
 	}
 
-	private ResultPartitionWriter createResultPartitionWriter(BufferProvider bufferProvider)
-			throws IOException {
+	/**
+	 * Partition writer that collects the added buffers/events in multiple queue.
+	 */
+	private static class CollectingPartitionWriter implements ResultPartitionWriter {
+		private final Queue<Buffer>[] queues;
+		private final BufferProvider bufferProvider;
+		private final ResultPartitionID partitionId = new ResultPartitionID();
 
-		ResultPartitionWriter partitionWriter = mock(ResultPartitionWriter.class);
-		when(partitionWriter.getBufferProvider()).thenReturn(checkNotNull(bufferProvider));
-		when(partitionWriter.getNumberOfSubpartitions()).thenReturn(1);
+		/**
+		 * Create the partition writer.
+		 *
+		 * @param queues one queue per outgoing channel
+		 * @param bufferProvider buffer provider
+		 */
+		private CollectingPartitionWriter(Queue<Buffer>[] queues, BufferProvider bufferProvider) {
+			this.queues = queues;
+			this.bufferProvider = bufferProvider;
+		}
 
-		// Recycle each written buffer.
-		doAnswer(new Answer<Void>() {
-			@Override
-			public Void answer(InvocationOnMock invocation) throws Throwable {
-				((Buffer) invocation.getArguments()[0]).recycleBuffer();
+		@Override
+		public BufferProvider getBufferProvider() {
+			return bufferProvider;
+		}
 
-				return null;
-			}
-		}).when(partitionWriter).writeBuffer(any(Buffer.class), anyInt());
+		@Override
+		public ResultPartitionID getPartitionId() {
+			return partitionId;
+		}
 
-		return partitionWriter;
+		@Override
+		public int getNumberOfSubpartitions() {
+			return queues.length;
+		}
+
+		@Override
+		public int getNumTargetKeyGroups() {
+			return 1;
+		}
+
+		@Override
+		public void writeBuffer(Buffer buffer, int targetChannel) throws IOException {
+			queues[targetChannel].add(buffer);
+		}
+	}
+
+	private static BufferOrEvent parseBuffer(Buffer buffer, int targetChannel) throws IOException {
+		if (buffer.isBuffer()) {
+			return new BufferOrEvent(buffer, targetChannel);
+		} else {
+			// is event:
+			AbstractEvent event = EventSerializer.fromBuffer(buffer, RecordWriterTest.class.getClassLoader());
+			buffer.recycleBuffer(); // the buffer is not needed anymore
+			return new BufferOrEvent(event, targetChannel);
+		}
+	}
+
+	/**
+	 * Partition writer that recycles all received buffers and does no further processing.
+	 */
+	private static class RecyclingPartitionWriter implements ResultPartitionWriter {
+		private final BufferProvider bufferProvider;
+		private final ResultPartitionID partitionId = new ResultPartitionID();
+
+		private RecyclingPartitionWriter(BufferProvider bufferProvider) {
+			this.bufferProvider = bufferProvider;
+		}
+
+		@Override
+		public BufferProvider getBufferProvider() {
+			return bufferProvider;
+		}
+
+		@Override
+		public ResultPartitionID getPartitionId() {
+			return partitionId;
+		}
+
+		@Override
+		public int getNumberOfSubpartitions() {
+			return 1;
+		}
+
+		@Override
+		public int getNumTargetKeyGroups() {
+			return 1;
+		}
+
+		@Override
+		public void writeBuffer(Buffer buffer, int targetChannel) throws IOException {
+			buffer.recycleBuffer();
+		}
 	}
 
 	private static class ByteArrayIO implements IOReadableWritable {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferListener;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.AddCredit;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
@@ -443,12 +444,12 @@ public class PartitionRequestClientHandlerTest {
 			int backlog) throws IOException {
 
 		// Mock buffer to serialize
-		BufferResponse resp = new BufferResponse(buffer, sequenceNumber, receivingChannelId, backlog);
+		BufferResponse resp = new BufferResponse((NetworkBuffer) buffer, sequenceNumber, receivingChannelId, backlog);
 
 		ByteBuf serialized = resp.write(UnpooledByteBufAllocator.DEFAULT);
 
 		// Skip general header bytes
-		serialized.readBytes(NettyMessage.HEADER_LENGTH);
+		serialized.readBytes(NettyMessage.FRAME_HEADER_LENGTH);
 
 		// Deserialize the bytes again. We have to go this way, because we only partly deserialize
 		// the header of the response and wait for a buffer from the buffer pool to copy the payload

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
@@ -45,6 +45,8 @@ public class SlotCountExceedingParallelismTest extends TestLogger {
 	private static final int NUMBER_OF_SLOTS_PER_TM = 2;
 	private static final int PARALLELISM = NUMBER_OF_TMS * NUMBER_OF_SLOTS_PER_TM;
 
+	public static final String JOB_NAME = "SlotCountExceedingParallelismTest (no slot sharing, blocking results)";
+
 	private static TestingCluster flink;
 
 	@BeforeClass
@@ -63,19 +65,23 @@ public class SlotCountExceedingParallelismTest extends TestLogger {
 	}
 
 	@Test
-	public void testNoSlotSharingAndBlockingResult() throws Exception {
-		final String jobName = "SlotCountExceedingParallelismTest (no slot sharing, blocking results)";
-
+	public void testNoSlotSharingAndBlockingResultSender() throws Exception {
 		// Sender with higher parallelism than available slots
-		JobGraph jobGraph = createTestJobGraph(jobName, PARALLELISM * 2, PARALLELISM);
+		JobGraph jobGraph = createTestJobGraph(JOB_NAME, PARALLELISM * 2, PARALLELISM);
 		submitJobGraphAndWait(jobGraph);
+	}
 
+	@Test
+	public void testNoSlotSharingAndBlockingResultReceiver() throws Exception {
 		// Receiver with higher parallelism than available slots
-		jobGraph = createTestJobGraph(jobName, PARALLELISM, PARALLELISM * 2);
+		JobGraph jobGraph = createTestJobGraph(JOB_NAME, PARALLELISM, PARALLELISM * 2);
 		submitJobGraphAndWait(jobGraph);
+	}
 
+	@Test
+	public void testNoSlotSharingAndBlockingResultBoth() throws Exception {
 		// Both sender and receiver with higher parallelism than available slots
-		jobGraph = createTestJobGraph(jobName, PARALLELISM * 2, PARALLELISM * 2);
+		JobGraph jobGraph = createTestJobGraph(JOB_NAME, PARALLELISM * 2, PARALLELISM * 2);
 		submitJobGraphAndWait(jobGraph);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

With this PR, based on #5, we finally pass our own `NetworkBuffer` class to Netty and remove one buffer copy while transferring data. Note that this applies to the sender side only.

Note that since we are using off-heap network buffers, Netty may even be able to send the buffers directly to the underlying network stack without another (internal) copy.

## Brief change log

- extend `NettyMessage#allocateBuffer()` to allow allocation for the header only
- extend `NettyMessage.BufferResponse` to assemble a composite buffer based on a (pooled) header buffer and our `NetworkBuffer` instance.

## Verifying this change

This change added tests and can be verified as follows:

- existing `NettyMessageSerializationTest` for the immediate encode-decode path of the new buffer
- any other (integration) test that uses the network stack for the full stack with something else than an `EmbeddedChannel`
- manually verified a streaming program (WordCount) on a 4 node local setup (different processes) with 1 JobManager and 4 TaskManagers

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dataartisans/flink/4)
<!-- Reviewable:end -->
