### PR TITLE
[hotfix][tests] Log test method name in RescalingITCase

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/LogTestName.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/LogTestName.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.testutils;
+
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+/**
+ * Log the currently running test. Can be used if each test method executes quickly enough, but they all together
+ * can cause Travis to fail with timeout.
+ *
+ * <p>Typical usage:
+ *
+ * <p>{@code @Rule public LogTestName logTestName = new LogTestName();}
+ */
+public class LogTestName extends TestWatcher {
+	@Override
+	protected void starting(Description description) {
+		System.out.println(String.format("Running %s", description));
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -51,12 +51,14 @@ import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.testutils.LogTestName;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -97,6 +99,9 @@ public class RescalingITCase extends TestLogger {
 	public static Object[] data() {
 		return new Object[]{"filesystem", "rocksdb"};
 	}
+
+	@Rule
+	public LogTestName logTestName = new LogTestName();
 
 	@Parameterized.Parameter
 	public String backend;


### PR DESCRIPTION
RescalingITCase is either flaky or takes too much time too execute causing Travis timeouts. Logging test method name should either solve the issue or help to solve it.